### PR TITLE
Add support for LCH color format

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -158,12 +158,14 @@ identifier_name:
   excluded:
     - 'x'
     - 'y'
+    - 'z'
     - 'a'
     - 'b'
     - 'x1'
     - 'x2'
     - 'y1'
     - 'y2'
+    - 'z2'
 deployment_target:
   macOS_deployment_target: '11'
 custom_rules:

--- a/Color Picker.xcodeproj/project.pbxproj
+++ b/Color Picker.xcodeproj/project.pbxproj
@@ -445,7 +445,7 @@
 			repositoryURL = "https://github.com/sindresorhus/Regex";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.1.0;
+				minimumVersion = 0.1.1;
 			};
 		};
 		E394DAAC263E95D900F5B042 /* XCRemoteSwiftPackageReference "LaunchAtLogin" */ = {

--- a/Color Picker.xcodeproj/xcshareddata/xcschemes/Color Picker.xcscheme
+++ b/Color Picker.xcodeproj/xcshareddata/xcschemes/Color Picker.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E3A3B11825904E7B001B4D0C"
+               BuildableName = "Color Picker.app"
+               BlueprintName = "Color Picker"
+               ReferencedContainer = "container:Color Picker.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E3A3B11825904E7B001B4D0C"
+            BuildableName = "Color Picker.app"
+            BlueprintName = "Color Picker"
+            ReferencedContainer = "container:Color Picker.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E3A3B11825904E7B001B4D0C"
+            BuildableName = "Color Picker.app"
+            BlueprintName = "Color Picker"
+            ReferencedContainer = "container:Color Picker.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Color Picker/App.swift
+++ b/Color Picker/App.swift
@@ -27,15 +27,19 @@ struct AppMain: App {
 					Button("Copy as HSL") {
 						appState.colorPanel.hslColorString.copyToPasteboard()
 					}
-						.keyboardShortcut("L")
+						.keyboardShortcut("S")
 					Button("Copy as RGB") {
 						appState.colorPanel.rgbColorString.copyToPasteboard()
 					}
 						.keyboardShortcut("R")
+					Button("Copy as LCH") {
+						appState.colorPanel.rgbColorString.copyToPasteboard()
+					}
+						.keyboardShortcut("L")
 					Button("Paste") {
 						appState.pasteColor()
 					}
-						.help("Paste color in the format Hex, HSL, or RGB")
+						.help("Paste color in the format Hex, HSL, RGB, or LCH")
 						.keyboardShortcut("V")
 						.disabled(NSColor.fromPasteboardGraceful(.general) == nil)
 				}

--- a/Color Picker/AppState.swift
+++ b/Color Picker/AppState.swift
@@ -29,6 +29,10 @@ final class AppState: ObservableObject {
 		colorPanel.accessoryView = accessoryView
 		accessoryView.constrainEdgesToSuperview()
 
+		// This has to be after adding the accessory view to get correct size.
+		colorPanel.setFrameUsingName(SSApp.name)
+		colorPanel.setFrameAutosaveName(SSApp.name)
+
 		return colorPanel
 	}()
 
@@ -121,6 +125,8 @@ final class AppState: ObservableObject {
 			colorPanel.hslColorString.copyToPasteboard()
 		case .rgb:
 			colorPanel.rgbColorString.copyToPasteboard()
+		case .lch:
+			colorPanel.lchColorString.copyToPasteboard()
 		}
 	}
 
@@ -143,6 +149,6 @@ final class AppState: ObservableObject {
 			return
 		}
 
-		colorPanel.color = color
+		colorPanel.color = color.usingColorSpace(.sRGB) ?? color
 	}
 }

--- a/Color Picker/ColorPickerView.swift
+++ b/Color Picker/ColorPickerView.swift
@@ -19,7 +19,7 @@ private struct BarView: View {
 			} label: {
 				Image(systemName: "paintbrush.fill")
 			}
-				.help("Paste color in the format Hex, HSL, or RGB")
+				.help("Paste color in the format Hex, HSL, RGB, or LCH")
 				.keyboardShortcut("V")
 				.disabled(NSColor.fromPasteboardGraceful(.general) == nil)
 			Spacer()
@@ -39,6 +39,7 @@ struct ColorPickerView: View {
 	@State private var hexColor = ""
 	@State private var hslColor = ""
 	@State private var rgbColor = ""
+	@State private var lchColor = ""
 	@State private var isPreventingUpdate = false
 	@State private var isTextFieldFocused = false
 
@@ -103,7 +104,7 @@ struct ColorPickerView: View {
 					Image(systemName: "doc.on.doc.fill")
 						.controlSize(.small)
 				}
-					.keyboardShortcut("L")
+					.keyboardShortcut("S")
 			}
 			HStack {
 				NativeTextField(
@@ -134,6 +135,35 @@ struct ColorPickerView: View {
 				}
 					.keyboardShortcut("R")
 			}
+			HStack {
+				NativeTextField(
+					text: $lchColor,
+					placeholder: "LCH",
+					font: .monospacedSystemFont(ofSize: 0, weight: .regular),
+					isFocused: $isTextFieldFocused
+				)
+					.controlSize(.large)
+					.onChange(of: lchColor) {
+						if
+							isTextFieldFocused,
+							!isPreventingUpdate,
+							let newColor = NSColor(cssLCHString: $0.trimmingCharacters(in: .whitespaces))
+						{
+							colorPanel.color = newColor
+						}
+
+						if !isPreventingUpdate {
+							updateColorsFromPanel(excludeLCH: true, preventUpdate: true)
+						}
+					}
+				Button {
+					lchColor.copyToPasteboard()
+				} label: {
+					Image(systemName: "doc.on.doc.fill")
+						.controlSize(.small)
+				}
+					.keyboardShortcut("L")
+			}
 		}
 			.padding(9)
 			// 244 makes `HSL` always fit in the text field.
@@ -161,6 +191,7 @@ struct ColorPickerView: View {
 		excludeHex: Bool = false,
 		excludeHSL: Bool = false,
 		excludeRGB: Bool = false,
+		excludeLCH: Bool = false,
 		preventUpdate: Bool = false
 	) {
 		if preventUpdate {
@@ -177,6 +208,10 @@ struct ColorPickerView: View {
 
 		if !excludeRGB {
 			rgbColor = colorPanel.rgbColorString
+		}
+
+		if !excludeLCH {
+			lchColor = colorPanel.lchColorString
 		}
 
 		if preventUpdate {
@@ -198,6 +233,10 @@ extension NSColorPanel {
 
 	var rgbColorString: String {
 		color.usingColorSpace(.sRGB)!.format(Defaults[.legacyColorSyntax] ? .rgbLegacy : .rgb)
+	}
+
+	var lchColorString: String {
+		color.usingColorSpace(.sRGB)!.format(.lch)
 	}
 }
 

--- a/Color Picker/Constants.swift
+++ b/Color Picker/Constants.swift
@@ -20,6 +20,7 @@ enum CopyColorFormat: String, Codable, CaseIterable {
 	case hex
 	case hsl
 	case rgb
+	case lch
 
 	var title: String {
 		switch self {
@@ -31,6 +32,8 @@ enum CopyColorFormat: String, Codable, CaseIterable {
 			return "HSL"
 		case .rgb:
 			return "RGB"
+		case .lch:
+			return "LCH"
 		}
 	}
 }

--- a/app-store-description.txt
+++ b/app-store-description.txt
@@ -3,7 +3,7 @@ Pick colors from anywhere using the built-in color picker.
 
 ■ Features
 
-- Quickly copy, paste, and convert colors in Hex, HSL, and RGB format
+- Quickly copy, paste, and convert colors in Hex, HSL, RGB, LCH format
 - Show as a normal app or in the menu bar
 - Toggle it from anywhere with a global keyboard shortcut
 - Make the window stay on top of all other windows
@@ -16,9 +16,10 @@ You can use the following keyboard shortcuts in the app:
 
 - Pick color: Command+p
 - Copy as Hex: Shift+Command+h
-- Copy as HSL: Shift+Command+l
+- Copy as HSL: Shift+Command+s
 - Copy as RGB: Shift+Command+r
-- Paste color: Shift+Command+v (In the format Hex, HSL, or RGB)
+- Copy as LCH: Shift+Command+l
+- Paste color: Shift+Command+v (In the format Hex, HSL, RGB, or LCH)
 
 
 ■ Support

--- a/app-store-keywords.txt
+++ b/app-store-keywords.txt
@@ -1,1 +1,1 @@
-color,picker,pick,system,colour,sample,sampler,builtin,wheel,rgb,hsl,hex,css,menu,bar,menubar
+color,picker,pick,system,colour,sample,sampler,builtin,wheel,hex,hsl,rgb,lch,css,menu,bar,menubar

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Requires macOS 11 or later.
 
 ## Features
 
-- Quickly copy, paste, and convert colors in Hex, HSL, and RGB format
+- Quickly copy, paste, and convert colors in Hex, HSL, RGB, LCH format
 - Show as a normal app or in the menu bar
 - Toggle it from anywhere with a global keyboard shortcut
 - Make the window stay on top of all other windows
@@ -31,9 +31,10 @@ You can use the following keyboard shortcuts in the app:
 
 - Pick color: <kbd>Command</kbd> <kbd>p</kbd>
 - Copy as Hex: <kbd>Shift</kbd> <kbd>Command</kbd> <kbd>h</kbd>
-- Copy as HSL: <kbd>Shift</kbd> <kbd>Command</kbd> <kbd>l</kbd>
+- Copy as HSL: <kbd>Shift</kbd> <kbd>Command</kbd> <kbd>s</kbd>
 - Copy as RGB: <kbd>Shift</kbd> <kbd>Command</kbd> <kbd>r</kbd>
-- Paste color: <kbd>Shift</kbd> <kbd>Command</kbd> <kbd>v</kbd> *(In the format Hex, HSL, or RGB)*
+- Copy as LCH: <kbd>Shift</kbd> <kbd>Command</kbd> <kbd>l</kbd>
+- Paste color: <kbd>Shift</kbd> <kbd>Command</kbd> <kbd>v</kbd> *(In the format Hex, HSL, RGB, or LCH)*
 
 ## Plugins
 
@@ -50,6 +51,10 @@ The built-in color picker supports plugins:
 ![](Stuff/screenshot2.jpg)
 
 ## FAQ
+
+#### What is LCH color?
+
+[It's a more human-friendly color format.](https://lea.verou.me/2020/04/lch-colors-in-css-what-why-and-how/)
 
 #### The color changes if I copy and then paste it
 


### PR DESCRIPTION
Fixes #5

Build: [Color Picker.app.zip](https://github.com/sindresorhus/System-Color-Picker/files/6508160/Color.Picker.app.zip)

**Please help test** 🙏


---

Open questions:

- Should LCH be clamped to sRGB? Currently, if you copy LCH, it will be clamped to sRGB. Same if you paste a LCH color that is outside the range of sRGB. How will browsers handle this?

TODO:

- [ ] I want to make it possible to hide/show the different color formats.